### PR TITLE
Fix markdown styling to be html styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
 
     <main>
         <h3>Welcome to the Home Page:</h3>
-        <p>I am thinking of shipping like this. I need to ship something before SoM ends.</p>
+        <p>I am thinking of shipping like this. I need to ship <i>something</i> before SoM ends.</p>
     </main>
 </body>
 </html>


### PR DESCRIPTION
As the title suggests, html does not do italics with underscores, instead it does it with the <i> tag.